### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Linting is done using PHP Code Sniffer (phpcs) with a specific moodle standard.
 
 Somes links:
 
-- https://github.com/squizlabs/PHP_CodeSniffer
+- https://github.com/PHPCSStandards/PHP_CodeSniffer
 - https://docs.moodle.org/dev/Linting#PHP_.28PHP_CodeSniffer.29 (Linting article on Moodle doc)
 - https://docs.moodle.org/dev/Setting_up_Sublime2 (specific article on setting up Sublime Text for Moodle development)
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932