### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: moodle-mod-wooflash
+  description: "Moodle plugin for Wooflash (https://www.wooflash.com)"
+  annotations:
+    github.com/project-slug: wooclap/moodle-mod_wooflash
+spec:
+  type: other
+  lifecycle: production
+  owner: group:default/developers

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: moodle-mod-wooflash
-  description: "Moodle plugin for Wooflash (https://www.wooflash.com)"
+  description: "Public Moodle plugin for Wooflash (https://www.wooflash.com)"
   annotations:
     github.com/project-slug: wooclap/moodle-mod_wooflash
 spec:


### PR DESCRIPTION
## What is this?

This PR adds a `catalog-info.yaml` file for [Backstage](https://backstage.io), our internal developer portal.

This file allows Backstage to discover and display this repository in its software catalog, providing a central place to find documentation, ownership info, and service metadata.

## What to review

Please check that the following fields are correct:

- **`spec.type`** — Is this a `service`, `library`, `website`, `cli`, or `other`?
- **`spec.owner`** — Does the owner team look right?
- **`spec.lifecycle`** — Is this `production`, `experimental`, or `deprecated`?
- **`metadata.description`** — Does the description accurately describe this repo?

Feel free to adjust any values before merging.