### PR TITLE
2026052100 — add Moodle 5.2 support

### DIFF
--- a/backup/moodle2/backup_wooflash_activity_task.class.php
+++ b/backup/moodle2/backup_wooflash_activity_task.class.php
@@ -20,9 +20,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once __DIR__ . '/../../../../config.php';
+defined('MOODLE_INTERNAL') || die();
 
-require_once $CFG->dirroot . '/mod/wooflash/backup/moodle2/backup_wooflash_stepslib.php'; // Because it exists (must)
+require_once __DIR__ . '/backup_wooflash_stepslib.php'; // Because it exists (must)
 
 /**
  * wooflash backup task that provides all the settings and steps to perform one

--- a/backup/moodle2/backup_wooflash_stepslib.php
+++ b/backup/moodle2/backup_wooflash_stepslib.php
@@ -20,7 +20,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once __DIR__ . '/../../../../config.php';
+defined('MOODLE_INTERNAL') || die();
 
 /**
  * Define all the backup steps that will be used by the backup_wooflash_activity_task

--- a/backup/moodle2/restore_wooflash_activity_task.class.php
+++ b/backup/moodle2/restore_wooflash_activity_task.class.php
@@ -20,14 +20,14 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once __DIR__ . '/../../../../config.php';
+defined('MOODLE_INTERNAL') || die();
 
 /**
  * wooflash restore task that provides all the settings and steps to perform one
  * complete restore of the activity
  */
 
-require_once $CFG->dirroot . '/mod/wooflash/backup/moodle2/restore_wooflash_stepslib.php'; // Because it exists (must)
+require_once __DIR__ . '/restore_wooflash_stepslib.php'; // Because it exists (must)
 
 class restore_wooflash_activity_task extends restore_activity_task {
 

--- a/backup/moodle2/restore_wooflash_stepslib.php
+++ b/backup/moodle2/restore_wooflash_stepslib.php
@@ -20,7 +20,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once __DIR__ . '/../../../../config.php';
+defined('MOODLE_INTERNAL') || die();
 
 /**
  * Structure step to restore one wooflash activity

--- a/version.php
+++ b/version.php
@@ -23,6 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025031400;
+$plugin->version = 2026052100;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooflash';
+$plugin->supported = [404, 502];


### PR DESCRIPTION
- Bump plugin version to 2026052100
- Declare compatibility with Moodle 4.4 and 5.2 via \$plugin->supported = [404, 502]
- Replace bare require_once in backup files with defined('MOODLE_INTERNAL') || die()